### PR TITLE
Import OrderedDict from collections

### DIFF
--- a/parler_rest/fields.py
+++ b/parler_rest/fields.py
@@ -3,9 +3,14 @@
 Custom serializer fields for nested translations.
 """
 from __future__ import unicode_literals
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from django.utils.datastructures import SortedDict as OrderedDict
+
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework import serializers
-from rest_framework.compat import OrderedDict
 from rest_framework.fields import SkipField
 from parler.models import TranslatedFieldsModel
 from parler.utils.context import switch_language


### PR DESCRIPTION
Make parler_rest compatible with djangorestframework >= 3.3.0 by
importing OrderedDict from collections and fallback to importing it from
Django (for Python 2.6), because there is no OrderedDict anymore in
rest_framework.compat since 3.3.0.