### PR TITLE
tests: Fix tests by doing proper tearDown

### DIFF
--- a/testproj/tests.py
+++ b/testproj/tests.py
@@ -26,6 +26,10 @@ class CountryTranslatedSerializerTestCase(TestCase):
         self.instance.url = "http://es.wikipedia.org/wiki/Spain"
         self.instance.save()
 
+    def tearDown(self):
+        # Delete our instance to make sure that no language data is cached
+        self.instance.delete()
+
     def test_translations_serialization(self):
         expected = {
             'pk': self.instance.pk,


### PR DESCRIPTION
Parler caches the translations and that makes some of the tests fail
when they are ran after each other.  Make sure that cache is cleaned by
deleting our instance in the tearDown method.  This works, because
Parler cleans the caches in the delete method.