### PR TITLE
Add optional parameter in serializer context to restrict rendered languages

### DIFF
--- a/testproj/tests.py
+++ b/testproj/tests.py
@@ -37,10 +37,6 @@ class CountryTranslatedSerializerTestCase(TestCase):
         self.instance.url = "http://es.wikipedia.org/wiki/España"
         self.instance.save()
 
-    def tearDown(self):
-        # Delete our instance to make sure that no language data is cached
-        self.instance.delete()
-
     def test_translations_serialization(self):
         expected = {
             'pk': self.instance.pk,

--- a/testproj/tests.py
+++ b/testproj/tests.py
@@ -8,6 +8,7 @@ import unittest
 
 from django.test import TestCase
 from django.utils import six
+
 from parler.tests.utils import override_parler_settings
 
 from parler_rest.utils import create_translated_fields_serializer
@@ -53,6 +54,30 @@ class CountryTranslatedSerializerTestCase(TestCase):
             }
         }
         serializer = CountryTranslatedSerializer(self.instance)
+        six.assertCountEqual(self, serializer.data, expected)
+
+    def test_translations_serialization_only_some_languages(self):
+        self.instance.set_current_language('fr')
+        self.instance.name = "Espagne"
+        self.instance.url = "https://fr.wikipedia.org/wiki/Espagne"
+        self.instance.save_translations()
+        # So we got: en, es, fr: Let's drop the english
+        expected = {
+            'pk': self.instance.pk,
+            'country_code': 'ES',
+            'translations': {
+                'es': {
+                    'name': "Spain",
+                    'url': "http://en.wikipedia.org/wiki/Spain"
+                },
+                'fr': {
+                    'name': "Espagne",
+                    'url': "https://fr.wikipedia.org/wiki/Espagne"
+                },
+            }
+        }
+        context = {'languages': ['es', 'fr']}
+        serializer = CountryTranslatedSerializer(self.instance, context=context)
         six.assertCountEqual(self, serializer.data, expected)
 
     def test_translations_validation(self):


### PR DESCRIPTION
Hi,

Pretty straight forward: this filter translations by language_code in `to_representation`, when a list of languages is passed in the context. This is useful to avoid wasting unnecessary bandwidth.

```python
serializer = TranslatedSerializer(instance, context={'languages': ['en', 'fr']})
serializer.data  #  should not output all the available languages, but only english and french
```

The user would still be responsible of ensuring that the selected languages are available by calling `queryset.translated(...)` in the view. 

It will not do localization fallbacks either. It would probably be nice but I wasn't sure of how to go about it.

Thanks!