### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Usage
 * First make sure you have django-parler_ installed and configured.
 * Use the serializers as demonstrated below to expose the translations.
 
-First configure a model, following the `django-parler documentation <http://django-parler.readthedocs.org/en/latest/>`_::
+First configure a model, following the `django-parler documentation <https://django-parler.readthedocs.io/en/latest/>`_::
 
     from django.db import models
     from parler.models import TranslatableModel, TranslatedFields


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.